### PR TITLE
Add support for checking versions/changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.3.0
+
+- Fail on not changing the following:
+  - `CHANGELOG.md`
+  - `README.md`
+  - `package.json`'s `version` property
+
 ## 0.2.0
 
 - Add support for mocha JSON output files 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![npm version](https://badge.fury.io/js/duti.svg)](https://badge.fury.io/js/duti)
 ![dependencies](https://david-dm.org/smartprocure/duti.svg)
+[![CircleCI](https://circleci.com/gh/smartprocure/duti/tree/master.svg?style=svg)](https://circleci.com/gh/smartprocure/duti/tree/master)
 
 # Duti :poop:
 **D**anger **Uti**lities

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "duti",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "duti": "bin/duti.js"
   },
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "src/index.js",
   "license": "MIT",
   "engines": {

--- a/src/duties/index.js
+++ b/src/duties/index.js
@@ -1,5 +1,6 @@
 let pr = require('./pr')
 let lint = require('./lint')
 let testResults = require('./testResults')
+let library = require('./library')
 
-module.exports = Object.assign({}, pr, lint, testResults)
+module.exports = Object.assign({}, pr, lint, testResults, library)

--- a/src/duties/library.js
+++ b/src/duties/library.js
@@ -6,8 +6,12 @@ let emptyChangelog = ({ danger, fail }) => {
   }
 }
 
-let versionBump = ({ danger, fail }) => {
-  if (!_.includes('version', danger.git.diffForFile('version'))) {
+let versionBump = async ({ danger, fail }) => {
+  let versionChanged = _.includes(
+    'version',
+    _.get('diff', await danger.git.diffForFile('package.json')),
+  )
+  if (!versionChanged) {
     fail('The version was not updated. Please update the version.')
   }
 }

--- a/src/duties/library.js
+++ b/src/duties/library.js
@@ -1,0 +1,25 @@
+let _ = require('lodash/fp')
+
+let emptyChangelog = ({ danger, fail }) => {
+  if (!_.includes('CHANGELOG.md', danger.git.modified_files)) {
+    fail('The changelog has not been updated. Please update the changelog.')
+  }
+}
+
+let versionBump = ({ danger, fail }) => {
+  if (!_.includes('version', danger.git.diffForFile('version'))) {
+    fail('The version was not updated. Please update the version.')
+  }
+}
+
+let readmeUpdate = ({ danger, fail }) => {
+  if (!_.includes('README.md', danger.git.modified_files)) {
+    fail('The README has not been updated. Please update the README.')
+  }
+}
+
+module.exports = {
+  emptyChangelog,
+  versionBump,
+  readmeUpdate,
+}

--- a/src/duties/library.spec.js
+++ b/src/duties/library.spec.js
@@ -1,6 +1,5 @@
 /* eslint-env jest */
 let { emptyChangelog, versionBump, readmeUpdate } = require('./library')
-let _ = require('lodash/fp')
 
 describe('emptyChangelog', () => {
   it('fails if the changelog has not been updated', () => {

--- a/src/duties/library.spec.js
+++ b/src/duties/library.spec.js
@@ -18,19 +18,23 @@ describe('emptyChangelog', () => {
 })
 
 describe('versionBump', () => {
-  it('fails if the version was not bumped', () => {
+  it('fails if the version was not bumped', async () => {
     let fail = jest.fn()
-    let diffForFile = jest.fn(() => [''])
+    let diffForFile = jest.fn(async () => ({
+      diff: '',
+    }))
     let danger = { git: { diffForFile } }
-    versionBump({ danger, fail })
+    await versionBump({ danger, fail })
     expect(fail).toHaveBeenCalled()
   })
 
-  it('doesnt fails if the version was not bumped', () => {
+  it('doesnt fails if the version was bumped', async () => {
     let fail = jest.fn()
-    let diffForFile = jest.fn(() => ['version'])
+    let diffForFile = jest.fn(async () => ({
+      diff: '{"version": "1.0.0"}',
+    }))
     let danger = { git: { diffForFile } }
-    versionBump({ danger, fail })
+    await versionBump({ danger, fail })
     expect(fail).not.toHaveBeenCalled()
   })
 })

--- a/src/duties/library.spec.js
+++ b/src/duties/library.spec.js
@@ -1,0 +1,53 @@
+/* eslint-env jest */
+let { emptyChangelog, versionBump, readmeUpdate } = require('./library')
+let _ = require('lodash/fp')
+
+describe('emptyChangelog', () => {
+  it('fails if the changelog has not been updated', () => {
+    let fail = jest.fn()
+    let danger = { git: { modified_files: [] } }
+    emptyChangelog({ danger, fail })
+    expect(fail).toHaveBeenCalled()
+  })
+
+  it('doesnt fail if the changelog has been updated', () => {
+    let fail = jest.fn()
+    let danger = { git: { modified_files: ['CHANGELOG.md'] } }
+    emptyChangelog({ danger, fail })
+    expect(fail).not.toHaveBeenCalled()
+  })
+})
+
+describe('versionBump', () => {
+  it('fails if the version was not bumped', () => {
+    let fail = jest.fn()
+    let diffForFile = jest.fn(() => [''])
+    let danger = { git: { diffForFile } }
+    versionBump({ danger, fail })
+    expect(fail).toHaveBeenCalled()
+  })
+
+  it('doesnt fails if the version was not bumped', () => {
+    let fail = jest.fn()
+    let diffForFile = jest.fn(() => ['version'])
+    let danger = { git: { diffForFile } }
+    versionBump({ danger, fail })
+    expect(fail).not.toHaveBeenCalled()
+  })
+})
+
+describe('readmeUpdate', () => {
+  it('fails if the readme has not been updated', () => {
+    let fail = jest.fn()
+    let danger = { git: { modified_files: [] } }
+    readmeUpdate({ danger, fail })
+    expect(fail).toHaveBeenCalled()
+  })
+
+  it('doesnt fail if the readme has been updated', () => {
+    let fail = jest.fn()
+    let danger = { git: { modified_files: ['README.md'] } }
+    readmeUpdate({ danger, fail })
+    expect(fail).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
This lets us fail if there are no changes in the changelog/readme/package.json version property