### PR TITLE
Do not import Danger globals in the dangerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.14.3
+* Do not import Danger globals in the dangerfile
+
 ## 0.14.2
 * Bump dependencies to fix Circle issue
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "duti",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "duti": "bin/duti"
   },
-  "version": "0.14.2",
+  "version": "0.14.3",
   "main": "src/index.js",
   "repository": {
     "type": "git",

--- a/src/dangerfile.js
+++ b/src/dangerfile.js
@@ -1,4 +1,4 @@
-let { message, danger, schedule, fail, warn, markdown } = require('danger')
+/* global message danger schedule fail warn markdown */
 let _ = require('lodash/fp')
 let Promise = require('bluebird')
 let cosmiconfig = require('cosmiconfig')


### PR DESCRIPTION
See https://github.com/danger/danger-js/blob/master/source/danger.ts for
the scoop. There's a throw there, so evaluating the dangerfile fails
when running danger locally with `danger ci` or `danger pr`. This should
be harmless because the dangerfile is (and should) only ever be imported
by danger itself, which injects the `danger` global.