### PR TITLE
Support arbitrary file extensions for changelog & readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.15.2
+* Support arbitrary file extensions for changelog & readme
+
 ## 0.15.1
 * Do not import Danger globals in the dangerfile
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "duti",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "duti": "bin/duti"
   },
-  "version": "0.15.1",
+  "version": "0.15.2",
   "main": "src/index.js",
   "repository": {
     "type": "git",

--- a/src/duties/library.js
+++ b/src/duties/library.js
@@ -2,8 +2,7 @@ let _ = require('lodash/fp')
 
 let emptyChangelog = ({ danger, fail }) => {
   if (
-    !_.includes('CHANGELOG.md', danger.git.modified_files) &&
-    !_.includes('CHANGELOG.md', danger.git.added_files)
+    !/changelog/i.test([danger.git.modified_files, danger.git.added_files])
   ) {
     fail('The changelog has not been updated. Please update the changelog.')
   }
@@ -20,7 +19,7 @@ let versionBump = async ({ danger, fail }) => {
 }
 
 let readmeUpdate = ({ danger, warn }) => {
-  if (!_.includes('README.md', danger.git.modified_files)) {
+  if (!/readme/i.test(danger.git.modified_files)) {
     warn('The README has not been updated. Please update the README.')
   }
 }

--- a/src/duties/library.js
+++ b/src/duties/library.js
@@ -1,9 +1,7 @@
 let _ = require('lodash/fp')
 
 let emptyChangelog = ({ danger, fail }) => {
-  if (
-    !/changelog/i.test([danger.git.modified_files, danger.git.added_files])
-  ) {
+  if (!/changelog/i.test([danger.git.modified_files, danger.git.added_files])) {
     fail('The changelog has not been updated. Please update the changelog.')
   }
 }

--- a/src/duties/library.spec.js
+++ b/src/duties/library.spec.js
@@ -22,6 +22,16 @@ describe('emptyChangelog', () => {
     emptyChangelog({ danger, fail })
     expect(fail).not.toHaveBeenCalled()
   })
+
+  it('works with arbitrary file extensions and alternate casing', () => {
+    let fail = jest.fn()
+    emptyChangelog({ danger: { git: { added_files: ['changelog'] } }, fail })
+    emptyChangelog({
+      danger: { git: { added_files: ['cHaNgElOg.creole'] } },
+      fail,
+    })
+    expect(fail).not.toHaveBeenCalled()
+  })
 })
 
 describe('versionBump', () => {
@@ -58,6 +68,16 @@ describe('readmeUpdate', () => {
     let warn = jest.fn()
     let danger = { git: { modified_files: ['README.md'] } }
     readmeUpdate({ danger, warn })
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('works with arbitrary file extensions and casing', () => {
+    let warn = jest.fn()
+    readmeUpdate({ danger: { git: { modified_files: ['README'] } }, warn })
+    readmeUpdate({
+      danger: { git: { modified_files: ['readme.asciidoc'] } },
+      warn,
+    })
     expect(warn).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Github supports a ton of different filetypes for its markup files, not just markdown: https://github.com/github/markup/blob/master/README.md#markups

So, given that the alternative should require it to check for _all_ of those, Duti should probably just not care about the extension. ¯\\\_(ツ)\_/¯

Bonus: it's now case-insensitive, too