### PR TITLE
Update futil-js -> futil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.15.3
+* Update all mentions of `futil-js` to `futil`
+
 ## 0.15.2
 * Support arbitrary file extensions for changelog & readme
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1710,9 +1710,9 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
-    "futil-js": {
+    "futil": {
       "version": "1.55.0",
-      "resolved": "https://registry.npmjs.org/futil-js/-/futil-js-1.55.0.tgz",
+      "resolved": "https://registry.npmjs.org/futil/-/futil-1.55.0.tgz",
       "integrity": "sha512-rYfg4rDMD7O0VI8ExlDrGHhazNXezHrb9BrjFB+mC0RuVNg/HqnYokWPbbxKyoY+HZiUa03lREw2rgrnt1QYxw==",
       "requires": {
         "babel-polyfill": "6.26.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "bluebird": "^3.5.0",
     "cosmiconfig": "^2.2.2",
-    "futil-js": "^1.54.0",
+    "futil": "^1.54.0",
     "lodash": "^4.17.11",
     "pkg-up": "^2.0.0",
     "strip-ansi": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "duti": "bin/duti"
   },
-  "version": "0.15.2",
+  "version": "0.15.3",
   "main": "src/index.js",
   "repository": {
     "type": "git",

--- a/src/duties/pr.js
+++ b/src/duties/pr.js
@@ -1,5 +1,5 @@
 let _ = require('lodash/fp')
-let F = require('futil-js')
+let F = require('futil')
 let { toSentence } = require('underscore.string')
 
 let prAssignee = ({ danger, fail }) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,7 +5,7 @@ let Promise = require('bluebird')
 let path = require('path')
 let pkgup = require('pkg-up')
 let _ = require('lodash/fp')
-let F = require('futil-js')
+let F = require('futil')
 
 Promise.promisifyAll(fs)
 


### PR DESCRIPTION
This PR proposes to update all mentions of `futil-js` to `futil` as the former has been [deprecated](https://github.com/smartprocure/futil-js/issues/117#issue-246338364).