### PR TITLE
Updated the peer depency to be more permissive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.15.4
+* Update the peer dependency to be more permissive
+
 ## 0.15.3
 * Update all mentions of `futil-js` to `futil`
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "duti": "bin/duti"
   },
-  "version": "0.15.3",
+  "version": "0.15.4",
   "main": "src/index.js",
   "repository": {
     "type": "git",
@@ -53,6 +53,6 @@
     "prettier": "^1.5.3"
   },
   "peerDependencies": {
-    "danger": "^6.0.0"
+    "danger": ">=6.0.0"
   }
 }


### PR DESCRIPTION
Running into the following using npm 7
```
» npm install
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: feathers-elastic-apm-node@1.0.1
npm ERR! Found: danger@10.6.6
npm ERR! node_modules/danger
npm ERR!   dev danger@"^10.5.4" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer danger@"^6.0.0" from duti@0.15.2
npm ERR! node_modules/duti
npm ERR!   dev duti@"^0.15.2" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /Users/kurtrudolph/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/kurtrudolph/.npm/_logs/2021-07-14T16_56_38_535Z-debug.log
```